### PR TITLE
MOVEM.W M,regs tries to sign extend before storing in registers, but …

### DIFF
--- a/cpu/movem.c
+++ b/cpu/movem.c
@@ -6,7 +6,7 @@
 
 static void movem_w(struct cpu *cpu, WORD op, int rmask)
 {
-  WORD d;
+  LONG d;
   LONG a;
   int i,savecycle,rev,inc,cnt;
 


### PR DESCRIPTION
…for that to work, the intermediate variable must be a LONG not a WORD