### PR TITLE
Enable/disable debug build

### DIFF
--- a/configure
+++ b/configure
@@ -1,15 +1,20 @@
 #!/bin/bash
 
+debug=
 prefix=/usr/local
 
 while test -n "$1"; do
     case "$1" in  
         --prefix) prefix="$2"; shift ;;
-	--prefix=*) prefix=`echo "$1" | awk -F= '{ print $2 }'`
+	--prefix=*) prefix=`echo "$1" | awk -F= '{ print $2 }'` ;;
+	--enable-debug) debug=yes ;;
+	--disable-debug) debug= ;;
     esac
     shift
 done
 
-echo "prefix=\"$prefix\"" > config.mk
+> config.mk
+echo "prefix=\"$prefix\"" >> config.mk
+test -n "$debug" && echo "CFLAGS_BASE += -DDBG" >> config.mk
 
 exit 0

--- a/diag.h
+++ b/diag.h
@@ -26,6 +26,8 @@ extern void print_diagnostic(int, struct mmu *, const char *, ...);
 #define INFO(FORMAT, ...)   print_diagnostic(4, mmu_device, FORMAT, ##__VA_ARGS__)
 // Step-by-step description of internal mechanisms.
 #define DEBUG(FORMAT, ...)  print_diagnostic(5, mmu_device, FORMAT, ##__VA_ARGS__)
+
+#ifdef DBG
 // Feel free to call this just about CPU instruction.
 #define TRACE(FORMAT, ...)  print_diagnostic(6, mmu_device, FORMAT, ##__VA_ARGS__)
 // Feel free to call this just about every clock cycle.
@@ -36,6 +38,11 @@ extern void print_diagnostic(int, struct mmu *, const char *, ...);
     if(!(CONDITION))					\
       FATAL("Assertion failed: %s", #CONDITION);	\
   } while(0)
+#else
+#define ASSERT(CONDITION)
+#define TRACE(FORMAT, ...)
+#define CLOCK(FORMAT, ...)
+#endif
 
 #define HANDLE_DIAGNOSTICS(device)				\
 static struct mmu *mmu_device = NULL;				\

--- a/floppy_stx.c
+++ b/floppy_stx.c
@@ -290,7 +290,7 @@ static void load_track(struct floppy *fl, FILE *fp)
   BYTE data[50000];
   BYTE *fuzzy_pos;
   BYTE *data_pos;
-  int track_image_offset = 0;
+  int track_image_offset __attribute__((unused)) = 0;
   int i;
 
   if(fread(header, 16, 1, fp) != 1) {


### PR DESCRIPTION
 Makes it possible to configure a build with or without debugging features.  This does not apply to the MonST-like debugger.

Debugging is enabled by adding `-DDBG` to `CFLAGS`.  This can be done in `config.mk` or by running `./configure --enable-debug`.  