### PR TITLE
Revert 2c wait in cpu_step_cycle until prefetch is handled the correct way

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -1159,8 +1159,13 @@ static int cpu_step_cycle(int cpu_run_state)
 
   /* A new instruction will only start on multiple of 2 cycles, so if
    * that is not the case, exit and let it increment up to the proper point
+   *
+   * Until all instructions handle their own prefetch (of the next instruction)
+   * completely as a state of its own, this needs to do 4c align, so while
+   * this is a temporary revert, it is necessary until prefetch is done
+   * the right way.
    */
-  if((cpu->cycle&1) != 0) {
+  if((cpu->cycle&3) != 0) {
     return CPU_OK;
   }
 


### PR DESCRIPTION
Right now prefetch is implemented to make sure the next instruction is fetched before that memory is overwritten (self modification). This is an incomplete implementation.

In reality, every instruction should prefetch the next instruction as a state in its execution. The next instruction should then start immediately, not wait for the next 4c align (the opcode is already inside the CPU, so no time is needed).

The 2c align in cpu_step_cycle doesn't do this the right way. Since every (almost) instruction end on a 4c boundary, it will nearly cause a 2c gap between instructions, and also misalign the next one in all these cases.

Until prefetch is done right, it should remain 4c aligned, and just keep going as before.