### PR TITLE
Clocked BRA, BSR, Bcc, and CLR

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -1360,7 +1360,7 @@ void cpu_init_clocked()
   
   reset_init((void *)instr_clocked, (void *)instr_print);
   cmpi_init((void *)instr_clocked, (void *)instr_print);
-  bcc_init((void *)instr_clocked, (void *)instr_print);
+  bcc_instr_init((void *)instr_clocked, (void *)instr_print);
 
   sub_init((void *)instr_clocked, (void *)instr_print);
   suba_init((void *)instr_clocked, (void *)instr_print);

--- a/cpu.c
+++ b/cpu.c
@@ -1383,7 +1383,7 @@ void cpu_init_clocked()
   scc_init((void *)instr_clocked, (void *)instr_print);
   dbcc_init((void *)instr_clocked, (void *)instr_print);
 
-  clr_init((void *)instr_clocked, (void *)instr_print);
+  clr_instr_init((void *)instr_clocked, (void *)instr_print);
   cmpa_init((void *)instr_clocked, (void *)instr_print);
 
   asl_init((void *)instr_clocked, (void *)instr_print);

--- a/cpuinstr/bcc.c
+++ b/cpuinstr/bcc.c
@@ -1,0 +1,229 @@
+#include "common.h"
+#include "cpu.h"
+#include "cprint.h"
+#include "mmu.h"
+
+#define BCC_NOT_TAKEN   1
+#define BSR_PUSH        2
+#define BCC_PREFETCH_1  3
+#define BCC_PREFETCH_2  4
+
+static void bcc(struct cpu *cpu, WORD op)
+{
+  SLONG o;
+  static int w;
+  static int saved_pc;
+
+  ENTER;
+  
+  switch(cpu->instr_state) {
+  case INSTR_STATE_NONE:
+    ADD_CYCLE(2);
+
+    w = 0;
+    o = (SLONG)(SBYTE)(op&0xff);
+    if(!o) {
+      o = bus_read_word(cpu->pc);
+      if(o&0x8000) o |= 0xffff0000;
+      o -= 2;
+      cpu->pc += 2;
+      w = 1;
+    }
+
+    switch((op&0xf00)>>8) {
+    case 0: /* BRA */
+      cpu->pc += o;
+      cpu->instr_state = BCC_PREFETCH_1;
+      break;
+    case 1: /* BSR */
+      saved_pc = cpu->pc;
+      cpu->pc += o;
+      cpu->instr_state = BSR_PUSH;
+      break;
+    case 2: /* BHI */
+      if(!CHKC && !CHKZ) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 3: /* BLS */
+      if(CHKC || CHKZ) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 4: /* BCC */
+      if(!CHKC) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 5: /* BCS */
+      if(CHKC) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 6: /* BNE */
+      if(!CHKZ) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 7: /* BEQ */
+      if(CHKZ) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 8: /* BVC */
+      if(!CHKV) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 9: /* BVS */
+      if(CHKV) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 10: /* BPL */
+      if(!CHKN) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 11: /* BMI */
+      if(CHKN) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 12: /* BGE */
+      if((CHKN && CHKV) || (!CHKN && !CHKV)) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 13: /* BLT */
+      if((CHKN && !CHKV) || (!CHKN && CHKV)) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 14: /* BGT */
+      if((CHKN && CHKV && !CHKZ) || (!CHKN && !CHKV && !CHKZ)) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    case 15: /* BLE */
+      if(CHKZ || (CHKN && !CHKV) || (!CHKN && CHKV)) {
+        cpu->instr_state = BCC_PREFETCH_1;
+        cpu->pc += o;
+      } else {
+        cpu->instr_state = BCC_NOT_TAKEN;
+      }
+      break;
+    }
+    break;
+  case BCC_NOT_TAKEN:
+    ADD_CYCLE(2);
+    if(w)
+      cpu->instr_state = BCC_PREFETCH_1;
+    else
+      cpu->instr_state = BCC_PREFETCH_2;
+    break;
+  case BSR_PUSH:
+    ADD_CYCLE(8);
+    cpu->a[7] -= 4;
+    bus_write_long(cpu->a[7], saved_pc);
+    cpu->instr_state = BCC_PREFETCH_1;
+    break;
+  case BCC_PREFETCH_1:
+    ADD_CYCLE(4);
+    cpu->instr_state = BCC_PREFETCH_2;
+    break;
+  case BCC_PREFETCH_2:
+    ADD_CYCLE(4);
+    cpu->instr_state = INSTR_STATE_FINISHED;
+    break;
+  }
+}
+
+static struct cprint *bcc_print(LONG addr, WORD op)
+{
+  LONG a;
+  int s;
+  static char *cond[16] = {
+    "BRA", "BSR", "BHI", "BLS", "BCC", "BCS", "BNE", "BEQ",
+    "BVC", "BVS", "BPL", "BMI", "BGE", "BLT", "BGT", "BLE"
+  };
+  struct cprint *ret;
+
+  ret = cprint_alloc(addr);
+
+  a = op&0xff;
+  if(a&0x80) a |= 0xffffff00;
+
+  if(a) {
+    s = 1;
+  } else {
+    s = 0;
+    a = bus_read_word_print(addr+ret->size);
+    if(a&0x8000) a |= 0xffff0000;
+  }
+
+  a += addr+ret->size;
+
+  if(!s) ret->size += 2;
+
+  strcpy(ret->instr, cond[(op&0xf00)>>8]);
+  if(s) strcat(ret->instr, ".S");
+  
+  cprint_set_label(a, NULL);
+  if(cprint_find_label(a)) {
+    sprintf(ret->data, "%s", cprint_find_label(a));
+  } else {
+    sprintf(ret->data, "$%x", a);
+  }
+
+  return ret;
+}
+
+void bcc_instr_init(void *instr[], void *print[])
+{
+  int i;
+  
+  for(i=0;i<0x1000;i++) {
+    instr[0x6000|i] = (void *)bcc;
+    print[0x6000|i] = (void *)bcc_print;
+  }
+}

--- a/cpuinstr/bcc.c
+++ b/cpuinstr/bcc.c
@@ -11,9 +11,8 @@
 
 static void bcc(struct cpu *cpu, WORD op)
 {
-  SLONG o;
+  static SLONG o;
   static int w;
-  static int saved_pc;
 
   ENTER;
   
@@ -37,8 +36,6 @@ static void bcc(struct cpu *cpu, WORD op)
       cpu->instr_state = BCC_PREFETCH_1;
       break;
     case 1: /* BSR */
-      saved_pc = cpu->pc;
-      cpu->pc += o;
       cpu->instr_state = BSR_PUSH_1;
       break;
     case 2: /* BHI */
@@ -165,13 +162,14 @@ static void bcc(struct cpu *cpu, WORD op)
   case BSR_PUSH_1:
     ADD_CYCLE(4);
     cpu->a[7] -= 4;
-    bus_write_word(cpu->a[7], saved_pc >> 16);
+    bus_write_word(cpu->a[7], cpu->pc >> 16);
     cpu->instr_state = BSR_PUSH_2;
     break;
   case BSR_PUSH_2:
     ADD_CYCLE(4);
-    bus_write_word(cpu->a[7] + 2, saved_pc);
+    bus_write_word(cpu->a[7] + 2, cpu->pc);
     cpu->instr_state = BCC_PREFETCH_1;
+    cpu->pc += o;
     break;
   case BCC_PREFETCH_1:
     ADD_CYCLE(4);

--- a/cpuinstr/clr.c
+++ b/cpuinstr/clr.c
@@ -1,0 +1,80 @@
+#include "common.h"
+#include "cpu.h"
+#include "cprint.h"
+#include "ea.h"
+
+#define CLR_PREFETCH  1
+#define CLR_WRITE     2
+
+static void clr(struct cpu *cpu, WORD op)
+{
+  ENTER;
+
+  switch(cpu->instr_state) {
+  case INSTR_STATE_NONE:
+    switch((op&0xc0)>>6) {
+    case 0: ea_read_byte(cpu, op&0x3f, 1); break;
+    case 1: ea_read_word(cpu, op&0x3f, 1); break;
+    case 2: ea_read_long(cpu, op&0x3f, 1); break;
+    }
+    cpu->instr_state = CLR_PREFETCH;
+    break;
+  case CLR_PREFETCH:
+    ADD_CYCLE(4);
+    cpu->instr_state = CLR_WRITE;
+    break;
+  case CLR_WRITE:
+    switch((op&0xc0)>>6) {
+    case 0: ea_write_byte(cpu, op&0x3f, 0); break;
+    case 1: ea_write_word(cpu, op&0x3f, 0); break;
+    case 2:
+      ea_write_long(cpu, op&0x3f, 0);
+      // Clearing a data register takes two additional cycles.
+      if(((op&0x38)>>3) == 0)
+	ADD_CYCLE(2);
+      break;
+    }
+    cpu->instr_state = INSTR_STATE_FINISHED;
+    cpu_set_flags_clr(cpu);
+    break;
+  }
+}
+
+static struct cprint *clr_print(LONG addr, WORD op)
+{
+  struct cprint *ret;
+
+  ret = cprint_alloc(addr);
+  
+  switch((op&0xc0)>>6) {
+  case 0:
+    strcpy(ret->instr, "CLR.B");
+    break;
+  case 1:
+    strcpy(ret->instr, "CLR.W");
+    break;
+  case 2:
+    strcpy(ret->instr, "CLR.L");
+    break;
+  }
+  ea_print(ret, op&0x3f, 0);
+
+  return ret;
+}
+
+void clr_instr_init(void *instr[], void *print[])
+{
+  int i;
+  
+  for(i=0;i<0x40;i++) {
+    if(ea_valid(i, EA_INVALID_DST|EA_INVALID_A)) {
+      instr[0x4200|i] = clr;
+      instr[0x4240|i] = clr;
+      instr[0x4280|i] = clr;
+      print[0x4200|i] = clr_print;
+      print[0x4240|i] = clr_print;
+      print[0x4280|i] = clr_print;
+    }
+  }
+}
+

--- a/cpuinstr/cpuinstr.mk
+++ b/cpuinstr/cpuinstr.mk
@@ -8,7 +8,7 @@
 #     eori_to_sr.c rol.c roxl.c not.c ror.c neg.c subi.c move_to_ccr.c	\
 #     ori_to_ccr.c addx.c cmpm.c subx.c eori_to_ccr.c negx.c linea.c	\
 #     roxr.c bchg.c abcd.c stop.c sbcd.c tas.c andi_to_ccr.c rtr.c)
-CPUINSTR_SRC=$(addprefix cpuinstr/,bcc.c exg.c movem.c)
+CPUINSTR_SRC=$(addprefix cpuinstr/,bcc.c clr.c exg.c movem.c)
 CPUINSTR_OBJ=$(CPUINSTR_SRC:.c=.o)
 
 -include $(CPUINSTR_SRC:.c=.d)

--- a/cpuinstr/cpuinstr.mk
+++ b/cpuinstr/cpuinstr.mk
@@ -8,7 +8,7 @@
 #     eori_to_sr.c rol.c roxl.c not.c ror.c neg.c subi.c move_to_ccr.c	\
 #     ori_to_ccr.c addx.c cmpm.c subx.c eori_to_ccr.c negx.c linea.c	\
 #     roxr.c bchg.c abcd.c stop.c sbcd.c tas.c andi_to_ccr.c rtr.c)
-CPUINSTR_SRC=$(addprefix cpuinstr/,movem.c exg.c)
+CPUINSTR_SRC=$(addprefix cpuinstr/,bcc.c exg.c movem.c)
 CPUINSTR_OBJ=$(CPUINSTR_SRC:.c=.o)
 
 -include $(CPUINSTR_SRC:.c=.d)


### PR DESCRIPTION
 There are empty microcycles for prefetch.  They should be filled later.

I'm not sure how the `ea_read...` and `ea_write...` functions work.  I'm assuming they should add to the instruction cycle times.  And I half-guessed what to do about the `noupdate` argument.