### PR TITLE
Fix CLOCK cycle display with clocked CPU

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -1245,6 +1245,7 @@ static int cpu_clock(int cpu_run_state)
      */
     return cpu_instr_done(cpu_run_state);
   } else {
+    cpu->clock = cpu->cycle;
     glue_clock();
     mmu_clock();
     shifter_clock();


### PR DESCRIPTION
 The CLOCK diagnostics rely on cpu->clock, which wasn't updated in the clocked CPU.

(In the future, perhaps only one of cpu->cycle and cpu->clock should remain.)