### PR TITLE
The shifter should read from RAM without the usual wait states

### DIFF
--- a/mmu.c
+++ b/mmu.c
@@ -555,7 +555,7 @@ void mmu_clock(void)
   // MMU can only access RAM at cycle 2 within a bus cycle.
   if((clock & 3) == 2 && (load & -4) == 0) {
     CLOCK("LOAD");
-    shifter_load(ram_read_word(scrptr));
+    shifter_load(ram_read_word_shifter(scrptr));
     scrptr += 2;
     load = de ? 4 : -1;
   }

--- a/ram.c
+++ b/ram.c
@@ -34,6 +34,12 @@ WORD ram_read_word(LONG addr)
   return (ram_read_byte(addr)<<8)|ram_read_byte(addr+1);
 }
 
+WORD ram_read_word_shifter(LONG addr)
+{
+  if(addr > RAM_PHYSMAX) return 0;
+  return (*real(addr) << 8) + *real(addr+1);
+}
+
 static void ram_write_byte(LONG addr, BYTE data)
 {
   MMU_WAIT_STATES();

--- a/ram.h
+++ b/ram.h
@@ -3,6 +3,6 @@
 
 void ram_init();
 void ram_clear();
-WORD ram_read_word(LONG addr);
+WORD ram_read_word_shifter(LONG addr);
 
 #endif


### PR DESCRIPTION
 The MMU already inserts necessary delay cycles before sending data from RAM to the shifter.  The common ram_read_word should only be used by the CPU (and possibly other devices on the main bus).  