### PR TITLE
The shifter "loads" variable should never go beyond 4

### DIFF
--- a/shifter.c
+++ b/shifter.c
@@ -345,7 +345,7 @@ void shifter_clock(void)
 
 static void increment_loads(void)
 {
-  loads++;
+  loads = MIN(4, loads + 1);
 }
 
 static void set_counting(void)


### PR DESCRIPTION
The variable corresponds to a 4-bit shift register in the hardware.
It can only have the states 0000, 0001, 0011, 0111, or 1111.