### PR TITLE
Wait states

### DIFF
--- a/acia.c
+++ b/acia.c
@@ -70,6 +70,8 @@ static void acia_reset(void)
 static BYTE acia_read_byte(LONG addr)
 {
   BYTE data;
+
+  CLOCK("Wait states: 6");
   cpu_add_extra_cycles(6);
 
   switch(addr) {
@@ -92,6 +94,7 @@ static WORD acia_read_word(LONG addr)
 
 static void acia_write_byte(LONG addr, BYTE data)
 {
+  CLOCK("Wait states: 6");
   cpu_add_extra_cycles(6);
 
   switch(addr) {

--- a/cpu.c
+++ b/cpu.c
@@ -466,6 +466,7 @@ void cpu_set_sr(WORD sr)
 
 void cpu_prefetch()
 {
+  CLOCK("Prefetch");
   cpu->prefetched_instr = bus_read_word(cpu->pc);
   cpu->has_prefetched = 1;
 }

--- a/cpu.c
+++ b/cpu.c
@@ -1159,7 +1159,8 @@ static int cpu_step_cycle(int cpu_run_state)
    * this is a temporary revert, it is necessary until prefetch is done
    * the right way.
    */
-  if((cpu->cycle&3) != 0) {
+  if((cpu->cycle&3) != 0 && cpu->icycle == 0 &&
+     (cpu->instr_state == INSTR_STATE_NONE || PREVIOUS_INSTR_FINISHED(cpu))) {
     CLOCK("Wait states: 1");
     return CPU_OK;
   }

--- a/cpu.h
+++ b/cpu.h
@@ -98,8 +98,6 @@ extern int cprint_all;
 #endif
 #define MAX_CYCLE 8012800
 
-#define BUS_ADD_CYCLE(x) do { if(clocked_cpu) ADD_CYCLE(x); } while(0)
-
 #define MSKT 0x8000
 #define MSKS 0x2000
 #define MSKX 0x10

--- a/mmu.c
+++ b/mmu.c
@@ -380,12 +380,16 @@ LONG bus_read_long_print(LONG addr)
 
 BYTE bus_read_byte(LONG addr)
 {
-  return MEM_READ(byte, addr);
+  BYTE data = MEM_READ(byte, addr);
+  CLOCK("Bus read byte: %02x @ %06x", data, addr);
+  return data;
 }
 
 WORD bus_read_word(LONG addr)
 {
-  return MEM_READ(word, addr);
+  WORD data = MEM_READ(word, addr);
+  CLOCK("Bus read word: %04x @ %06x", data, addr);
+  return data;
 }
 
 LONG bus_read_long(LONG addr)
@@ -399,11 +403,13 @@ LONG bus_read_long(LONG addr)
 
 void bus_write_byte(LONG addr, BYTE data)
 {
+  CLOCK("Bus write byte: %02x @ %06x", data, addr);
   MEM_WRITE(byte, addr, data);
 }
 
 void bus_write_word(LONG addr, WORD data)
 {
+  CLOCK("Bus write word: %02x @ %06x", data, addr);
   MEM_WRITE(word, addr, data);
 }
 

--- a/mmu.h
+++ b/mmu.h
@@ -57,7 +57,7 @@ extern int mmu_print_state;
 #define MMU_WAIT_STATES()			\
   do {						\
     if(((cpu->clock + cpu->icycle) & 3) != 0) {	\
-      BUS_ADD_CYCLE(2);				\
+      ADD_CYCLE(2);				\
       CLOCK("Wait states: 2");			\
     }						\
   } while(0)

--- a/psg.c
+++ b/psg.c
@@ -204,6 +204,7 @@ static void psg_write_byte(LONG addr, BYTE data)
   if(addr&1) return;
   addr &= 2;
 
+  CLOCK("Wait states: 2");
   cpu_add_extra_cycles(2);
 
   switch(addr) {


### PR DESCRIPTION
Minor tweaks to how wait states are inserted.

Careful review of log files indicates that wait states appears where expected.  I didn't change wait states between instructions when not running from RAM.  I guess that can be done when prefetch has been improved.

Also verified with BIG Demo and Level 16 Full Screen Demo, without any regressions on clocked or old CPU mode.